### PR TITLE
add_admin_auth_route

### DIFF
--- a/src/controllers/auth_controller.js
+++ b/src/controllers/auth_controller.js
@@ -53,6 +53,7 @@ const AuthController = {
       user: {
         name: newUser.name,
         email: newUser.email,
+        isAdmin: newUser.isAdmin,
       },
     });
   },
@@ -92,8 +93,22 @@ const AuthController = {
       user: {
         name: user.name,
         email: user.email,
+        isAdmin: user.isAdmin,
       },
     });
+  },
+
+  elevateToAdmin: async (req, res, next) => {
+    const { password } = req.body;
+
+    if (password !== process.env.ADMIN_PASSWORD) {
+      throw new UnauthorizedError("Mot de passe incorrect.");
+    }
+
+    req.user.isAdmin = true;
+    await req.user.save();
+
+    res.status(200).json({ message: "Vous êtes désormais admin." });
   },
 };
 

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,12 +1,20 @@
 const express = require("express");
 const router = express.Router();
-const AuthController = require("../controllers/auth_controller");
+const authController = require("../controllers/auth_controller");
+const authMiddleware = require("../middlewares//auth_middleware");
 const asyncHandler = require("../middlewares/async-handler");
 
 // 🔑 Signup - POST /auth/signup
-router.post("/signup", asyncHandler(AuthController.signup));
+router.post("/signup", asyncHandler(authController.signup));
 
 // 🔐 Login - POST /auth/login
-router.post("/login", asyncHandler(AuthController.login));
+router.post("/login", asyncHandler(authController.login));
+
+// 👨‍💼 Elevate - POST /auth/elevate
+router.post(
+  "/elevate",
+  authMiddleware,
+  asyncHandler(authController.elevateToAdmin)
+);
 
 module.exports = router;


### PR DESCRIPTION
## ✨ PR – Route d'élévation en admin

### 📌 Objectif

Permettre à un utilisateur authentifié de **devenir admin** depuis le front, en saisissant un mot de passe sécurisé.

---

### 🔐 Endpoint ajouté

```http
POST /api/auth/elevate
```

### 🔸 Fonctionnement

- **Requiert l’authentification** (`authMiddleware`)
- Attend un champ `password` dans le body
- Compare le mot de passe à `process.env.ADMIN_PASSWORD`
- Si le mot de passe est correct :
  - le champ `isAdmin` de l’utilisateur est mis à `true`
  - une réponse `200 OK` est renvoyée avec un message
- Sinon : réponse `403 Forbidden`

---

### ✅ Exemple de requête

```http
POST /api/auth/elevate
Authorization: Bearer <token>
Content-Type: application/json

{
  "password": "super-admin-123"
}
```

---

### 📁 Modifications apportées

- 🔧 Route ajoutée dans `routes/auth.js`
- 🧠 Contrôleur `elevateToAdmin` dans `controllers/authController.js`
- 🔒 Vérification du mot de passe admin via `process.env.ADMIN_PASSWORD`
- 💥 Erreur levée en `ForbiddenError` en cas d’échec
