### PR TITLE
feat/quiz-publication

### DIFF
--- a/src/controllers/quiz_controller.js
+++ b/src/controllers/quiz_controller.js
@@ -1,4 +1,6 @@
 const Quiz = require("../models/Quiz");
+const findSubmissionsByQuizIdForUser = require("../services/quizzes/find_submissions_by_quiz_id");
+const { UnauthorizedError, NotFoundError } = require("../utils/errors");
 
 const QuizController = {
   postQuiz: async (req, res) => {
@@ -11,18 +13,41 @@ const QuizController = {
   },
 
   getAllQuiz: async (req, res) => {
-    const allQuiz = await Quiz.find();
+    const includeUnpublished = req.query.includeUnpublished === "true";
 
-    res.status(201).json(allQuiz);
+    if (includeUnpublished) {
+      if (!req.user.isAdmin) {
+        throw new UnauthorizedError(
+          "Seuls les admins peuvent accéder à tous les quiz, y compris les non publiés"
+        );
+      }
+
+      const allQuizzes = await Quiz.find();
+      return res.json(allQuizzes);
+    }
+
+    const quizzes = await Quiz.withPublishedVersions();
+    const submissionMap = await findSubmissionsByQuizIdForUser(
+      quizzes,
+      req.user._id
+    );
+
+    const data = quizzes.map((quiz) => ({
+      id: quiz._id,
+      title: quiz.title,
+      submissionId: submissionMap.get(quiz._id.toString()) || null,
+    }));
+
+    res.json(data);
   },
 
   getQuiz: async (req, res) => {
     const quiz = await Quiz.findById(req.params.id);
     if (!quiz) throw new NotFoundError("Quiz introuvable");
 
-    const latestVersion = await quiz.latestVersion();
-    const questionsCount = latestVersion
-      ? await latestVersion.questionsCount()
+    const latestPublishedVersion = await quiz.latestPublishedVersion();
+    const questionsCount = latestPublishedVersion
+      ? await latestPublishedVersion.questionsCount()
       : 0;
 
     res.status(200).json({

--- a/src/controllers/quiz_controller.js
+++ b/src/controllers/quiz_controller.js
@@ -15,7 +15,7 @@ const QuizController = {
     const filters = {};
 
     if (title) {
-      filters.title = new RegExp(title, "i");
+      filters.title = new RegExp(title, "gi");
     }
 
     const allQuiz = await Quiz.find(filters);

--- a/src/controllers/quiz_controller.js
+++ b/src/controllers/quiz_controller.js
@@ -11,7 +11,14 @@ const QuizController = {
   },
 
   getAllQuiz: async (req, res) => {
-    const allQuiz = await Quiz.find();
+    let title = req.query.title;
+    const filters = {};
+
+    if (title) {
+      filters.title = new RegExp(title, "i");
+    }
+
+    const allQuiz = await Quiz.find(filters);
 
     res.status(201).json(allQuiz);
   },

--- a/src/controllers/quizversion_controller.js
+++ b/src/controllers/quizversion_controller.js
@@ -30,13 +30,12 @@ const QuizVersionController = {
     if (!quiz) throw new NotFoundError("Quiz introuvable");
 
     const includeUnpublished = req.query.includeUnpublished === "true";
-    const isOwner = quiz.creator?.toString() === req.user._id.toString();
 
-    // if (includeUnpublished && !isOwner) {
-    //   throw new UnauthorizedError(
-    //     "Seul le créateur du quiz peut accéder aux versions non publiées"
-    //   );
-    // }
+    if (includeUnpublished && !req.user.isAdmin) {
+      throw new UnauthorizedError(
+        "Seul un administrateur peut accéder aux versions non publiées"
+      );
+    }
 
     const version = includeUnpublished
       ? await quiz.latestVersion()

--- a/src/controllers/quizversion_controller.js
+++ b/src/controllers/quizversion_controller.js
@@ -2,12 +2,13 @@ const QuizVersion = require("../models/QuizVersion");
 const Submission = require("../models/Submission");
 const Quiz = require("../models/Quiz");
 const Question = require("../models/Question");
-const { NotFoundError } = require("../utils/errors");
+const { NotFoundError, BadRequestError } = require("../utils/errors");
 const { UnauthorizedError } = require("../utils/errors");
 const QuizVersionShowSerializer = require("../serializers/quiz_versions/show_serializer");
 
 const QuizVersionController = {
   // GET - Récupérer toutes les versions de quiz
+  // Cette route semble inutile
   getQuizVersions: async (req, res) => {
     const quizVersions = await QuizVersion.find();
     return res.status(200).json({ message: quizVersions });
@@ -15,6 +16,7 @@ const QuizVersionController = {
 
   // GET - Récupérer toutes les versions d'un quiz spécifique via son ID
   // param : ID du quiz
+  // Cette route semble inutile
   getQuizVersionsByQuizId: async (req, res) => {
     const quizVersions = await QuizVersion.find({
       quiz: req.params.quizId,
@@ -23,14 +25,26 @@ const QuizVersionController = {
     return res.status(200).json({ quizVersions });
   },
 
-  getMostRecentVersionByQuizId: async (req, res, next) => {
+  getMostRecentVersionByQuizId: async (req, res) => {
     const quiz = await Quiz.findById(req.params.quizId);
     if (!quiz) throw new NotFoundError("Quiz introuvable");
 
-    const version = await quiz.latestVersion();
+    const includeUnpublished = req.query.includeUnpublished === "true";
+    const isOwner = quiz.creator?.toString() === req.user._id.toString();
 
-    if (!version)
+    // if (includeUnpublished && !isOwner) {
+    //   throw new UnauthorizedError(
+    //     "Seul le créateur du quiz peut accéder aux versions non publiées"
+    //   );
+    // }
+
+    const version = includeUnpublished
+      ? await quiz.latestVersion()
+      : await quiz.latestPublishedVersion();
+
+    if (!version) {
       throw new NotFoundError("Aucune version trouvée pour ce quiz");
+    }
 
     const questions = await Question.find({ quizVersion: version._id });
 
@@ -119,6 +133,25 @@ const QuizVersionController = {
     ).serialize();
 
     res.status(200).json(serialized);
+  },
+
+  publish: async (req, res) => {
+    const { id } = req.params;
+
+    const quizVersion = await QuizVersion.findById(id);
+    if (!quizVersion) throw new NotFoundError("QuizVersion non trouvée");
+
+    const questionCount = await Question.countDocuments({ quizVersion: id });
+    if (questionCount === 0) {
+      throw new BadRequestError(
+        "Impossible de publier un quiz sans questions."
+      );
+    }
+
+    quizVersion.isPublished = true;
+    await quizVersion.save();
+
+    res.status(200).json({ message: "Quiz publié avec succès" });
   },
 };
 

--- a/src/models/Quiz.js
+++ b/src/models/Quiz.js
@@ -12,7 +12,10 @@ QuizSchema.statics.withPublishedVersions = async function (filters) {
     .model("QuizVersion")
     .distinct("quiz", { isPublished: true });
 
-  return this.find({ _id: { $in: quizIds } }, ...filters);
+  return this.find({
+    _id: { $in: quizIds },
+    ...filters,
+  });
 };
 
 QuizSchema.methods.latestVersion = async function () {

--- a/src/models/Quiz.js
+++ b/src/models/Quiz.js
@@ -7,11 +7,28 @@ const QuizSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-QuizSchema.methods.latestVersion = function () {
-  return mongoose
+QuizSchema.statics.withPublishedVersions = async function () {
+  const quizIds = await mongoose
+    .model("QuizVersion")
+    .distinct("quiz", { isPublished: true });
+
+  return this.find({ _id: { $in: quizIds } });
+};
+
+QuizSchema.methods.latestVersion = async function () {
+  return await mongoose
     .model("QuizVersion")
     .findOne({ quiz: this._id })
     .sort({ createdAt: -1 });
+};
+
+QuizSchema.methods.latestPublishedVersion = async function () {
+  return await mongoose
+    .model("QuizVersion")
+    .findOne({ quiz: this._id, isPublished: true })
+    .sort({
+      createdAt: -1,
+    });
 };
 
 module.exports = mongoose.model("Quiz", QuizSchema);

--- a/src/models/QuizVersion.js
+++ b/src/models/QuizVersion.js
@@ -3,7 +3,8 @@ const mongoose = require("mongoose");
 const QuizVersionSchema = new mongoose.Schema(
   {
     title: { type: String, required: true },
-    durationInMinutes: { type: Number, required: true },
+    durationInMinutes: { type: Number },
+    isPublished: { type: Boolean, default: false },
     quiz: {
       type: mongoose.Schema.Types.ObjectId,
       ref: "Quiz",

--- a/src/routes/quizVersions.js
+++ b/src/routes/quizVersions.js
@@ -11,20 +11,30 @@ router.get(
   "/quiz_versions",
   asyncHandler(QuizVersionController.getQuizVersions)
 );
+
 router.get(
   "/quizzes/:quizId/quiz_versions",
   asyncHandler(QuizVersionController.getQuizVersionsByQuizId)
 );
+
 router.post(
   "/quizzes/:quizId/quiz_versions",
   adminOnly,
   asyncHandler(QuizVersionController.postQuizVersion)
 );
+
 router.put(
   "/quiz_versions/:id",
   adminOnly,
   asyncHandler(QuizVersionController.putQuizVersion)
 );
+
+router.put(
+  "/quiz_versions/:id/publish",
+  adminOnly,
+  asyncHandler(QuizVersionController.publish)
+);
+
 router.get(
   "/quizzes/:quizId/most_recent_quiz_version",
   asyncHandler(QuizVersionController.getMostRecentVersionByQuizId)

--- a/src/scripts/seed.js
+++ b/src/scripts/seed.js
@@ -121,6 +121,7 @@ const Answer = require("../models/Answer");
       title: "Quiz React useEffect v1",
       durationInMinutes: 20,
       quiz: quiz1._id,
+      isPublished: true,
     });
     const q1v1 = await Question.create({
       ...useEffectQ1,
@@ -140,6 +141,7 @@ const Answer = require("../models/Answer");
       title: "Quiz React useEffect v2",
       durationInMinutes: 20,
       quiz: quiz1._id,
+      isPublished: true,
     });
     const q1v2 = await Question.create({
       ...useEffectQ1,
@@ -160,6 +162,7 @@ const Answer = require("../models/Answer");
       title: "Quiz React Context v1",
       durationInMinutes: 15,
       quiz: quiz2._id,
+      isPublished: true,
     });
 
     const ctxQ1 = await Question.create({

--- a/src/serializers/quiz_versions/show_serializer.js
+++ b/src/serializers/quiz_versions/show_serializer.js
@@ -10,6 +10,8 @@ class QuizVersionShowSerializer {
       _id: this.version._id,
       title: this.version.title,
       durationInMinutes: this.version.durationInMinutes,
+      isPublished: this.version.isPublished,
+      quizId: this.version.quiz,
       questions: this.questions.map((q) => {
         const base = {
           _id: q._id,

--- a/src/services/quizzes/find_submissions_by_quiz_id.js
+++ b/src/services/quizzes/find_submissions_by_quiz_id.js
@@ -1,0 +1,40 @@
+const QuizVersion = require("../../models/QuizVersion");
+const Submission = require("../../models/Submission");
+
+const findSubmissionsByQuizIdForUser = async (quizzes, userId) => {
+  const quizIds = quizzes.map((q) => q._id);
+
+  const versions = await QuizVersion.find({
+    quiz: { $in: quizIds },
+    isPublished: true,
+  });
+
+  const versionMap = new Map(); // quizId => [versionIds]
+  versions.forEach((v) => {
+    const key = v.quiz.toString();
+    const current = versionMap.get(key) || [];
+    current.push(v._id.toString());
+    versionMap.set(key, current);
+  });
+
+  const versionIds = versions.map((v) => v._id);
+  const submissions = await Submission.find({
+    quizVersion: { $in: versionIds },
+    user: userId,
+  });
+
+  const submissionMap = new Map(); // quizId => submissionId
+  submissions.forEach((s) => {
+    const version = versions.find(
+      (v) => v._id.toString() === s.quizVersion.toString()
+    );
+    const quizId = version?.quiz?.toString();
+    if (quizId && !submissionMap.has(quizId)) {
+      submissionMap.set(quizId, s._id.toString());
+    }
+  });
+
+  return submissionMap;
+};
+
+module.exports = findSubmissionsByQuizIdForUser;

--- a/src/services/submissions.js
+++ b/src/services/submissions.js
@@ -101,6 +101,10 @@ module.exports = {
     await assertCohortExists(cohortId);
     await assertSubmissionNotExists(user, quizVersionId, cohortId);
 
+    if (!version.isPublished) {
+      throw new UnauthorizedError("Ce quiz n'est pas encore publié");
+    }
+
     const submission = new Submission({
       user,
       quizVersion: quizVersionId,


### PR DESCRIPTION
## 🎯 Feature: Quiz Publishing Workflow

### Contexte
Les administrateurs doivent pouvoir travailler sur une version de quiz en plusieurs étapes, et ne la rendre disponible aux élèves qu'une fois finalisée. Pour cela, nous introduisons un champ `isPublished` sur `QuizVersion` et modifions les comportements associés à la récupération, la visualisation et la soumission d’un quiz.

---

### ✅ Ce que contient cette PR

#### 🎛️ Modèle
- Ajout du champ `isPublished` (booléen, `false` par défaut) sur `QuizVersion`.
- Ajout des méthodes Mongoose :
  - `Quiz.latestVersion()`
  - `Quiz.latestPublishedVersion()`
  - `Quiz.withPublishedVersions()`

---

#### 📦 Contrôleurs

##### `QuizVersionController`
- ➕ `publish(req, res)`: publication explicite d'une version (PUT `/quiz_versions/:id/publish`)
  - Vérifie que la version existe
  - Vérifie qu’elle contient au moins une question
- 🔁 `getMostRecentVersionByQuizId(req, res)`
  - Accepte `?includeUnpublished=true`
  - Retourne `latestPublishedVersion()` si includeUnpublished est falsy, sinon retourne `latestVersion()` si l’utilisateur est admin, sinon erreur 403

##### `QuizController`
- 🔁 `getAllQuiz(req, res)`
  - Accepte le paramètre `?includeUnpublished=true`
  - Si `includeUnpublished=true` :
    - Retourne **tous les quiz** sans distinction de publication
    - ⚠️ Accessible **uniquement aux administrateurs** (`403 Forbidden` sinon)
  - Si le paramètre est absent ou `false` :
    - Retourne **uniquement les quiz ayant au moins une version publiée**
  - Dans tous les cas, ajoute un champ `submissionId` pour chaque quiz si l’utilisateur a déjà soumis des réponses à l’une de ses versions publiées

- 🔁 `getQuiz(req, res)`
  - Utilise `latestPublishedVersion()` à la place de `latestVersion()`

---

#### 🔐 Sécurité & règles métiers
- 🔐 Interdit aux élèves de répondre à un quiz non publié (`services/submissions.js`)
- 🔐 Empêche l'accès à des versions non publiées sauf si l’utilisateur est admin
- 🔐 Publication interdite si aucune question

---

### 🧪 Seed
- Les versions seedées sont toutes marquées comme `isPublished: true`

---

### 📁 Services
- `services/quizzes/find_submissions_by_quiz_id.js`
  - Centralise la logique de récupération des `submissionId` associés à l’utilisateur pour une liste de quiz

---

### 📎 Routes
- `PUT /quiz_versions/:id/publish` (admin uniquement)

---

### 💬 Discussion
- Séparation stricte entre logique de publication (`isPublished`) et accès (`includeUnpublished`)
- La logique de soumission (`POST /submissions`) impose que le quiz soit publié

---

### ✅ Testée avec succès :
- Création / update d'une `QuizVersion`
- Publication avec validation
- Affichage différencié côté élève et admin
- Soumission bloquée pour les versions non publiées
