### PR TITLE
feature/get_cohorts_and_users_that_submitted_a_quiz

### DIFF
--- a/src/controllers/cohorts_controller.js
+++ b/src/controllers/cohorts_controller.js
@@ -1,5 +1,7 @@
-const { AppError, ConflictError, NotFoundError } = require("../utils/errors");
+const { NotFoundError } = require("../utils/errors");
 const Cohort = require("../models/Cohort");
+const Quiz = require("../models/Quiz");
+const findCohortsWithSubmissionsForQuiz = require("../services/cohorts/findCohortsWithSubmissionsForQuiz");
 
 const getAllCohorts = async (req, res, next) => {
   //fecth all cohorts and get only _id and name field
@@ -18,4 +20,20 @@ const createCohort = async (req, res, next) => {
   res.status(201).json(newCohort);
 };
 
-module.exports = { getAllCohorts, createCohort };
+// GET /quizzes/:quizId/cohorts_with_submissions
+getCohortsWithSubmissions = async (req, res, next) => {
+  const { quizId } = req.params;
+
+  const quiz = await Quiz.findById(quizId);
+  if (!quiz) throw new NotFoundError("Quiz introuvable");
+
+  const cohorts = await findCohortsWithSubmissionsForQuiz(quiz);
+
+  res.json(cohorts);
+};
+
+module.exports = {
+  getAllCohorts,
+  createCohort,
+  getCohortsWithSubmissions,
+};

--- a/src/controllers/user_controller.js
+++ b/src/controllers/user_controller.js
@@ -1,4 +1,7 @@
 const User = require("../models/User");
+const Quiz = require("../models/Quiz");
+const { NotFoundError } = require("../utils/errors");
+const findUsersWithSubmissionsForCohort = require("../services/users/findUsersWithSubmissionsForCohort");
 
 const UsersController = {
   getUsers: async (req, res) => {
@@ -14,6 +17,16 @@ const UsersController = {
       .populate("cohorts", "name");
 
     res.status(200).json(users);
+  },
+
+  getUsersWithSubmissionsForCohort: async (req, res) => {
+    const { quizId, cohortId } = req.params;
+
+    const quiz = await Quiz.findById(quizId);
+    if (!quiz) throw new NotFoundError("Quiz introuvable");
+
+    const users = await findUsersWithSubmissionsForCohort(quiz, cohortId);
+    res.json(users);
   },
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ app.use(morgan("dev"));
 app.use("/api/auth", authRoutes);
 app.use("/api", QuizRoutes);
 app.use("/api", QuizVersionsRoutes);
-app.use("/api/cohorts", cohortsRoutes);
+app.use("/api", cohortsRoutes);
 app.use("/api", userRoutes);
 app.use("/api", submissionRoutes);
 

--- a/src/models/Quiz.js
+++ b/src/models/Quiz.js
@@ -14,4 +14,13 @@ QuizSchema.methods.latestVersion = function () {
     .sort({ createdAt: -1 });
 };
 
+QuizSchema.methods.getQuizVersionIds = async function () {
+  const versions = await mongoose
+    .model("QuizVersion")
+    .find({ quiz: this._id })
+    .select("_id");
+
+  return versions.map((v) => v._id);
+};
+
 module.exports = mongoose.model("Quiz", QuizSchema);

--- a/src/routes/cohorts_route.js
+++ b/src/routes/cohorts_route.js
@@ -1,13 +1,24 @@
 const express = require("express");
 const router = express.Router();
-const cohorts_controller = require("../controllers/cohorts_controller");
+const cohortsController = require("../controllers/cohorts_controller");
 const asyncHandler = require("../middlewares/async-handler");
 const authMiddleware = require("../middlewares/auth_middleware");
 const adminOnly = require("../middlewares/admin_only");
 
 router.use(authMiddleware);
 
-router.get("/", asyncHandler(cohorts_controller.getAllCohorts));
-router.post("/", adminOnly, asyncHandler(cohorts_controller.createCohort));
+router.get("/cohorts", asyncHandler(cohortsController.getAllCohorts));
+router.post(
+  "/cohorts",
+  adminOnly,
+  asyncHandler(cohortsController.createCohort)
+);
+
+// GET /quizzes/:quizId/cohorts_with_submissions
+router.get(
+  "/quizzes/:quizId/cohorts_with_submissions",
+  adminOnly,
+  asyncHandler(cohortsController.getCohortsWithSubmissions)
+);
 
 module.exports = router;

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -7,6 +7,14 @@ const adminOnly = require("../middlewares/admin_only");
 
 router.use(authMiddleware);
 
+// GET api/users
 router.get("/users", adminOnly, asyncHandler(UsersController.getUsers));
+
+// GET api/quizzes/:quizId/cohorts/:cohortId/users_with_submissions
+router.get(
+  "/quizzes/:quizId/cohorts/:cohortId/users_with_submissions",
+  adminOnly,
+  asyncHandler(UsersController.getUsersWithSubmissionsForCohort)
+);
 
 module.exports = router;

--- a/src/services/cohorts/findCohortsWithSubmissionsForQuiz.js
+++ b/src/services/cohorts/findCohortsWithSubmissionsForQuiz.js
@@ -1,0 +1,26 @@
+const Submission = require("../../models/Submission");
+const User = require("../../models/User");
+const Cohort = require("../../models/Cohort");
+
+const findCohortsWithSubmissionsForQuiz = async (quiz) => {
+  // 1. Récupérer les IDs des versions publiées du quiz via la méthode d'instance
+  const versionIds = await quiz.getQuizVersionIds();
+
+  // 2. Récupérer les userIds ayant soumis pour l'une de ces versions
+  const userIds = await Submission.distinct("user", {
+    quizVersion: { $in: versionIds },
+  });
+
+  if (userIds.length === 0) return [];
+
+  // 3. Extraire directement les cohort IDs distincts parmi ces users
+  const cohortIds = await User.distinct("cohorts", { _id: { $in: userIds } });
+  if (cohortIds.length === 0) return [];
+
+  // 4. Récupérer les cohortes correspondantes (le service retourne les objets Mongoose bruts)
+  const cohorts = await Cohort.find({ _id: { $in: cohortIds } });
+
+  return cohorts;
+};
+
+module.exports = findCohortsWithSubmissionsForQuiz;

--- a/src/services/users/findUsersWithSubmissionsForCohort.js
+++ b/src/services/users/findUsersWithSubmissionsForCohort.js
@@ -1,0 +1,48 @@
+const User = require("../../models/User");
+const Submission = require("../../models/Submission");
+const QuizVersion = require("../../models/QuizVersion");
+
+// Retourne les utilisateurs de la cohorte ayant soumis une réponse à **n'importe quelle version** du quiz donné
+const findUsersWithSubmissionsForCohort = async (quiz, cohortId) => {
+  // 1. Récupérer les versions du quiz
+  const versionIds = await quiz.getQuizVersionIds();
+  if (versionIds.length === 0) return [];
+
+  // 2. Récupérer les submissions associées à ces versions
+  const submissions = await Submission.find({
+    quizVersion: { $in: versionIds },
+  }).select("user");
+
+  const userIds = [...new Set(submissions.map((s) => s.user.toString()))];
+
+  if (userIds.length === 0) return [];
+
+  // 3. Récupérer les users appartenant à cette cohorte
+  const users = await User.find({
+    _id: { $in: userIds },
+    cohorts: cohortId,
+  }).select("name");
+
+  // 4. Récupérer leur submission (une seule par user max à renvoyer)
+  const submissionsByUser = await Submission.find({
+    quizVersion: { $in: versionIds },
+    user: { $in: users.map((u) => u._id) },
+  }).sort({ createdAt: 1 });
+
+  const submissionMap = new Map();
+  for (const s of submissionsByUser) {
+    const userId = s.user.toString();
+    if (!submissionMap.has(userId)) {
+      submissionMap.set(userId, s._id);
+    }
+  }
+
+  // 5. Construire la réponse
+  return users.map((u) => ({
+    id: u._id,
+    name: u.name,
+    submissionId: submissionMap.get(u._id.toString()),
+  }));
+};
+
+module.exports = findUsersWithSubmissionsForCohort;


### PR DESCRIPTION
## 🎯 Objectif de la PR

Cette PR introduit deux nouveaux endpoints permettant de récupérer des **informations analytiques** liées aux soumissions de quiz, afin d'alimenter le backoffice du frontend :

---

## 🚀 Nouvelles routes

### 1. Récupérer les cohortes ayant des soumissions sur un quiz

- **GET** `/quizzes/:quizId/cohorts_with_submissions`
- 🔒 Admin uniquement
- 📦 Retourne un tableau d’objets `{ id, name }` pour chaque cohorte contenant au moins un utilisateur ayant soumis une réponse à **n’importe quelle version** du quiz donné.

### 2. Récupérer les utilisateurs d’une cohorte ayant participé à un quiz

- **GET** `/quizzes/:quizId/cohorts/:cohortId/users_with_submissions`
- 🔒 Admin uniquement
- 📦 Retourne un tableau d’objets `{ id, name, submissionId }` pour chaque utilisateur de la cohorte ayant soumis une réponse à **n’importe quelle version** du quiz.

---

## 🧠 Implémentation technique

- Création de deux services dédiés :
  - `quiz.getQuizVersionIds()` → méthode d’instance qui retourne tous les IDs de version d’un quiz
  - `findCohortsWithSubmissionsForQuiz(quiz)` → retourne la liste des cohortes concernées
  - `findUsersWithSubmissionsForCohort(quiz, cohortId)` → retourne les utilisateurs ayant participé

- Utilisation de `Submission` pour déterminer les participations, et de `User.distinct("cohorts")` pour limiter les requêtes à la base.

---

## ✅ Tests réalisés

- Requête vers `/quizzes/:quizId/cohorts_with_submissions` avec et sans soumissions
- Requête vers `/quizzes/:quizId/cohorts/:cohortId/users_with_submissions` avec et sans résultats
- Vérification des rôles : seuls les admins peuvent accéder à ces routes

---

## 📎 Autres

- Pas de changement sur les modèles
- Le code respecte l’architecture existante : services bien isolés, controllers minimalistes

