### PR TITLE
delete_quiz_version

### DIFF
--- a/src/models/Quiz.js
+++ b/src/models/Quiz.js
@@ -32,6 +32,7 @@ QuizSchema.methods.getQuizVersionIds = async function () {
     .select("_id");
 
   return versions.map((v) => v._id);
+};
 
 QuizSchema.methods.latestPublishedVersion = async function () {
   return await mongoose

--- a/src/routes/quizVersions.js
+++ b/src/routes/quizVersions.js
@@ -40,4 +40,10 @@ router.get(
   asyncHandler(QuizVersionController.getMostRecentVersionByQuizId)
 );
 
+router.delete(
+  "/quiz_versions/:id",
+  adminOnly,
+  asyncHandler(QuizVersionController.deleteQuizVersion)
+);
+
 module.exports = router;

--- a/src/serializers/quiz_versions/show_serializer.js
+++ b/src/serializers/quiz_versions/show_serializer.js
@@ -1,7 +1,8 @@
 class QuizVersionShowSerializer {
-  constructor(quizVersion, questions = [], currentUser = null) {
+  constructor(quizVersion, questions = [], hasSubmissions, currentUser = null) {
     this.version = quizVersion;
     this.questions = questions;
+    this.hasSubmissions = hasSubmissions;
     this.currentUser = currentUser;
   }
 
@@ -11,6 +12,7 @@ class QuizVersionShowSerializer {
       title: this.version.title,
       durationInMinutes: this.version.durationInMinutes,
       isPublished: this.version.isPublished,
+      hasSubmissions: !!this.hasSubmissions,
       quizId: this.version.quiz,
       questions: this.questions.map((q) => {
         const base = {


### PR DESCRIPTION
### DELETE /api/quiz_versions/:id

Supprime une version de quiz (QuizVersion), uniquement si **aucune soumission** n’est associée à cette version.

**Réponse (succès, 204) :**

```json
204 No Content
```

**Réponse (échec – des soumissions existent, 409) :**

```json
{
  "message": "Impossible de supprimer cette version car des soumissions lui sont associées."
}
```

Ajout du champ hasSubmissions dans GET /api/quizzes/:quiz_id/most_recent_quiz_version